### PR TITLE
change logic in clients.yml to reflect the inventory hostname instead…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Vagrant_for_RHCSA
 The following instructions are how I set up for RHCSA,RHCE, and Ansible testing in my home lab.  
 The instructions were written for use in Windows environment, but can be adjusted accordingly for Linux.  
 Keep in mind that I have a "Controller" server for Ansible related tasks across the full lab.  
-Your Controller server should be configured to provide additionalo core services for your other servers.  
+Your Controller server should be configured to provide additional core services for your other servers.  
 The configuration of the lab services is outside the scope of this document. This document is strictly  
 related to the initial configuration of lab build out.  
 

--- a/provision/clients.yml
+++ b/provision/clients.yml
@@ -39,7 +39,7 @@
              BOOTPROTO=none
              ONBOOT="yes"
              TYPE=Ethernet
-             IPADDR="{% if ansible_distribution == 'Rocky' %}192.168.80.21{% elif ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 7 %}192.168.80.22{% elif ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 8 %}192.168.80.23{% else %}192.168.80.24{% endif %}"
+             IPADDR="{% if inventory_hostname == 'servera' %}192.168.80.21{% elif inventory_hostname == 'serverb' %}192.168.80.22{% elif inventory_hostname == 'serverc' %}192.168.80.23{% else %}192.168.80.24{% endif %}"
              NETMASK=255.255.255.0
              IPV6=no
              DEFROUTE=no


### PR DESCRIPTION
… of the distro. This will allow you to specify a distro in the vagrantfile without having to edit the yaml files to match a specific ansible_distribution